### PR TITLE
Improve heuristic to correctly tier the threshold by number of features

### DIFF
--- a/jsbits/Scenario.js
+++ b/jsbits/Scenario.js
@@ -212,9 +212,9 @@ function gm$smartProcessFeatureCollection(fc, coorSys, defVec, maxGeomId) {
                     transform = true;
                 }
             } // infer WGS84 if coorinate variance is small enough for a given number of objects in the scene
-            else if ((xbound < 1 && ybound < 1 && fc['features'].length < 10)  ||
-                     (xbound < 3 && ybound < 3 && fc['features'].length >= 10 && fc['features'].length < 100) ||
-                     (xbound < 5 && ybound < 5 && fc['features'].length >= 100)
+            else if ((xbound < 1 && ybound < 1)
+                  || (xbound < 3 && ybound < 3 && fc['features'].length >= 10)
+                  || (xbound < 5 && ybound < 5 && fc['features'].length >= 100)
                     ){
                 transform = true;
             }

--- a/jsbits/Scenario.js
+++ b/jsbits/Scenario.js
@@ -213,8 +213,8 @@ function gm$smartProcessFeatureCollection(fc, coorSys, defVec, maxGeomId) {
                 }
             } // infer WGS84 if coorinate variance is small enough for a given number of objects in the scene
             else if ((xbound < 1 && ybound < 1 && fc['features'].length < 10)  ||
-                     (xbound < 3 && ybound < 3 && fc['features'].length < 100) ||
-                     (xbound < 5 && ybound < 5 && fc['features'].length)
+                     (xbound < 3 && ybound < 3 && fc['features'].length >= 10 && fc['features'].length < 100) ||
+                     (xbound < 5 && ybound < 5 && fc['features'].length >= 100)
                     ){
                 transform = true;
             }


### PR DESCRIPTION
As we discussed earlier, we want to differentiate the threshold for xbound and ybound in respect to number of features. 

At the moment, if the condition of (xbound < 1 && ybound < 1 && fc['features'].length < 10) is true, then (xbound < 3 && ybound < 3 && fc['features'].length < 100) and (xbound < 5 && ybound < 5 && fc['features'].length) is also true, which means current version is just the same as checking (xbound < 5 && ybound < 5 && fc['features'].length).