### PR TITLE
Fix rotation bug and line string bug

### DIFF
--- a/src/Data/Geometry/Structure/LineString.hs
+++ b/src/Data/Geometry/Structure/LineString.hs
@@ -16,7 +16,7 @@
 
 module Data.Geometry.Structure.LineString
     ( LineString (), lineString
-    , MultiLineString (), multiLineString
+    , MultiLineString (), multiLineString, js_isEmptyMultiLineString
     ) where
 
 
@@ -77,6 +77,10 @@ lineString x y zs = fromJSArray . fromList $ x:y:zs
 {-# INLINE multiLineString #-}
 multiLineString :: [LineString n x] -> MultiLineString n x
 multiLineString = fromJSArray . fromList
+
+{-# INLINE js_isEmptyMultiLineString #-}
+foreign import javascript unsafe "$r = $1['coordinates'].length === 0; console.log($1);"
+    js_isEmptyMultiLineString ::  MultiLineString n x -> Bool
 
 ----------------------------------------------------------------------------------------------------
 -- LineString as PointSet

--- a/src/Data/Geometry/Structure/LineString.hs
+++ b/src/Data/Geometry/Structure/LineString.hs
@@ -16,7 +16,7 @@
 
 module Data.Geometry.Structure.LineString
     ( LineString (), lineString
-    , MultiLineString (), multiLineString, js_isEmptyMultiLineString
+    , MultiLineString (), multiLineString
     ) where
 
 
@@ -77,10 +77,6 @@ lineString x y zs = fromJSArray . fromList $ x:y:zs
 {-# INLINE multiLineString #-}
 multiLineString :: [LineString n x] -> MultiLineString n x
 multiLineString = fromJSArray . fromList
-
-{-# INLINE js_isEmptyMultiLineString #-}
-foreign import javascript unsafe "$r = $1['coordinates'].length === 0; console.log($1);"
-    js_isEmptyMultiLineString ::  MultiLineString n x -> Bool
 
 ----------------------------------------------------------------------------------------------------
 -- LineString as PointSet

--- a/src/Program/Model/City.hs
+++ b/src/Program/Model/City.hs
@@ -533,7 +533,7 @@ storeCityAsIs City
     , clutter = (mline, _)
     , cityTransform = (scale, shift)
     } = JS.fromJSArray . JS.fromList $
-          if LS.js_isEmptyMultiLineString mline
+          if JS.length mline == 0
           then buildingFeatures
           else lineFeature : buildingFeatures
   where

--- a/src/Program/Model/City.hs
+++ b/src/Program/Model/City.hs
@@ -533,11 +533,14 @@ storeCityAsIs City
     , clutter = (mline, _)
     , cityTransform = (scale, shift)
     } = JS.fromJSArray . JS.fromList $
-       (feature . PS.mapSet (\x -> x*scale3 + shift3) . GeoMultiLineString $ mline)
-        : JS.toList (JS.map (storeCityObject scale shift PlainFeature) buildings)
+          if LS.js_isEmptyMultiLineString mline
+          then buildingFeatures
+          else lineFeature : buildingFeatures
   where
     shift3 = resizeVector shift
     scale3 = broadcastVector (1/scale)
+    lineFeature = (feature . PS.mapSet (\x -> x*scale3 + shift3) . GeoMultiLineString $ mline)
+    buildingFeatures = JS.toList (JS.map (storeCityObject scale shift PlainFeature) buildings)
 
 storeObjectsAsIs :: [GeomId] -> City -> FeatureCollection
 -- TODO: Proper change in the logic?


### PR DESCRIPTION
1. The rotation bug in old qua-kit fix is put here. I create a new method for computing the oriented minimum area bounding rectangle for the polygon.
2. The line string bug fix. I do not create the combined MultiLineString object if there are no LineString/MultiLineString objects in the scenario